### PR TITLE
(feat): adiciona workflow para publicação automática no handbook

### DIFF
--- a/.github/workflows/publish_github_pages.yml
+++ b/.github/workflows/publish_github_pages.yml
@@ -1,0 +1,34 @@
+name: Publish documentation on GitHub pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'overrides/**'
+
+jobs:
+  publish_documentation_on_github_pages:
+    runs-on: Ubuntu-24.04
+    steps:
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.13
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Git user
+        uses: fregante/setup-git-user@v2
+
+      - name: Install packages
+        run: pip install -r requirements.txt
+
+      - name: Publish Documentation
+        run: mkdocs gh-deploy


### PR DESCRIPTION
Closes #10

Implementa a publicação automática das alterações no handbook da `splor-mg`. 

Inspirado no [automatiza](https://github.com/automatiza-mg/automatizacoes/blob/main/.github/workflows/publish_github_pages.yml) do Automatiza.MG.), atualizei as referências aos `github/actions` de `setup-python` para v5, com `python-version` definida em `3.13`, e `checkout` para v4. 
