### PR TITLE
Adiciona links para posts marcados na linha do tempo, fix #176

### DIFF
--- a/docs/linha_do_tempo/datamart.md
+++ b/docs/linha_do_tempo/datamart.md
@@ -1,3 +1,4 @@
+
 # Datamart
 
 > **AID-SPLOR/SEPLAG**
@@ -46,11 +47,15 @@
                    : Qualidade e validação dos dados
     ```
 
-??? info "Projeto no Github — Gestão à Vista"
+??? info "Links úteis"
 
     Acesse o painel do projeto no GitHub:
 
     [ Acessar Painel ](https://github.com/orgs/splor-mg/projects/13/views/28){ .md-button }
+
+    Posts sobre o Projeto Datamart:
+
+    [ Acessar Posts ]( https://splor-mg.github.io/handbook/blog/category/datamart){ .md-button }
 
 ??? success "Ganhos Esperados"
 

--- a/docs/linha_do_tempo/feed_legislativo.md
+++ b/docs/linha_do_tempo/feed_legislativo.md
@@ -1,3 +1,4 @@
+
 # Feed Legislativo
 
 > **AID-SPLOR/SEPLAG**
@@ -37,11 +38,11 @@
         Próximos Passos : Melhorias no Subworkflows e buscas
     ```
 
-??? info "Projeto no Github — Gestão à Vista"
+??? info "Links úteis"
 
-    Acesse o painel do projeto no GitHub:
+    Acesse os Issues do projeto no GitHub:
 
-    [ Acessar Painel ](https://github.com/orgs/splor-mg/projects/13/views/15?sliceBy%5Bvalue%5D=Feed+Legislativo){ .md-button }
+    [ Acessar Issues ](https://github.com/orgs/splor-mg/projects/13/views/15?sliceBy%5Bvalue%5D=Feed+Legislativo){ .md-button }
 
 ??? success "Ganhos Esperados"
 

--- a/docs/linha_do_tempo/index.md
+++ b/docs/linha_do_tempo/index.md
@@ -12,4 +12,12 @@ Além disso, a linha do tempo é um recurso valioso para a comunicação com as 
 
 A construção rotineira dessas linhas do tempo, para além dos ganhos já destacados, contribui para o aprimoramento da **documentação dos projetos**, permitindo a preservação do conhecimento institucional e a continuidade das iniciativas. Esse processo, consigo, impulsiona a **gestão do conhecimento,** viabilizando análises mais assertivas e promovendo um ambiente de **aprendizado contínuo**.
 
+## Projetos
+
+- [Projeto Dados Abertos MG](https://splor-mg.github.io/handbook/linha_do_tempo/projeto_dados_abertos_mg/)
+- [DataMart](https://splor-mg.github.io/handbook/linha_do_tempo/datamart/)
+- [Painéis](https://splor-mg.github.io/handbook/linha_do_tempo/paineis/)
+- [Volumes LOA](https://splor-mg.github.io/handbook/linha_do_tempo/volumes_loa/)
+- [Feed Legislativo](https://splor-mg.github.io/handbook/linha_do_tempo/feed_legislativo/)
+
 [^1]: Criado com auxílio de [Mermaid timelines](https://mermaid.js.org/syntax/timeline.html).

--- a/docs/linha_do_tempo/index.md
+++ b/docs/linha_do_tempo/index.md
@@ -14,10 +14,10 @@ A construção rotineira dessas linhas do tempo, para além dos ganhos já desta
 
 ## Projetos
 
-- [Projeto Dados Abertos MG](https://splor-mg.github.io/handbook/linha_do_tempo/projeto_dados_abertos_mg/)
-- [DataMart](https://splor-mg.github.io/handbook/linha_do_tempo/datamart/)
-- [Painéis](https://splor-mg.github.io/handbook/linha_do_tempo/paineis/)
-- [Volumes LOA](https://splor-mg.github.io/handbook/linha_do_tempo/volumes_loa/)
-- [Feed Legislativo](https://splor-mg.github.io/handbook/linha_do_tempo/feed_legislativo/)
+- [Projeto Dados Abertos MG](../linha_do_tempo/projeto_dados_abertos_mg/)
+- [DataMart](../linha_do_tempo/datamart/)
+- [Painéis](../linha_do_tempo/paineis/)
+- [Volumes LOA](../linha_do_tempo/volumes_loa/)
+- [Feed Legislativo](../linha_do_tempo/feed_legislativo/)
 
 [^1]: Criado com auxílio de [Mermaid timelines](https://mermaid.js.org/syntax/timeline.html).

--- a/docs/linha_do_tempo/paineis.md
+++ b/docs/linha_do_tempo/paineis.md
@@ -1,3 +1,4 @@
+
 # Painéis
 
 > **AID-SPLOR/SEPLAG**
@@ -38,11 +39,11 @@
                    : Adicionar dados de outras variáveis orçamentárias ao repo
     ```
 
-??? info "Projeto no Github — Gestão à Vista"
+??? info "Links úteis"
 
-    Acesse o painel do projeto no GitHub:
+    Acesse os Issues do projeto no GitHub:
 
-    [ Acessar Painel ](https://github.com/orgs/splor-mg/projects/13/views/15?sliceBy%5Bvalue%5D=Paineis){ .md-button }
+    [ Acessar Issues ](https://github.com/orgs/splor-mg/projects/13/views/15?sliceBy%5Bvalue%5D=Paineis){ .md-button }
 
 ??? success "Ganhos Esperados"
 

--- a/docs/linha_do_tempo/volumes_loa.md
+++ b/docs/linha_do_tempo/volumes_loa.md
@@ -1,3 +1,4 @@
+
 # Volumes LOA
 
 > **AID-SPLOR/SEPLAG**
@@ -40,11 +41,15 @@
                    : Configuração do Dockerhub
     ```
 
-??? info "Projeto no Github — Gestão à Vista"
+??? info "Links úteis"
 
-    Acesse o painel do projeto no GitHub:
+    Acesse os Issues do projeto no GitHub:
 
-    [ Acessar Painel ](https://github.com/orgs/splor-mg/projects/13/views/15?sliceBy%5Bvalue%5D=Volumes+LOA){ .md-button }
+    [ Acessar Issues ](https://github.com/orgs/splor-mg/projects/13/views/15?sliceBy%5Bvalue%5D=Volumes+LOA){ .md-button }
+
+    Posts sobre o Projeto Volumes LOA:
+
+    [ Acessar Posts ]( https://splor-mg.github.io/handbook/blog/category/volumes-loa){ .md-button }
 
 ??? success "Ganhos Esperados"
 


### PR DESCRIPTION
Adiciona links para posts que contém tag (Datamart e Volume LOA). Além disso, adiciona link dos projetos na página inicial da linha do tempo. See #176 